### PR TITLE
Support for numa interleaving when running within a container

### DIFF
--- a/Dockerfile.templ
+++ b/Dockerfile.templ
@@ -16,6 +16,7 @@ RUN apt-get update && \
         ca-certificates \
         pwgen \
         wget \
+        numactl \
     && \
     rm -rf /var/lib/apt/lists/* && \
     wget ${ARANGO_SIGNATURE_URL} &&       \

--- a/Dockerfile31.templ
+++ b/Dockerfile31.templ
@@ -18,6 +18,7 @@ RUN apt-get update && \
         ca-certificates \
         pwgen \
         curl \
+        numactl \
     && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile32.templ
+++ b/Dockerfile32.templ
@@ -22,6 +22,7 @@ RUN apt-get update && \
         ca-certificates \
         pwgen \
         curl \
+        numactl \
     && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile33.templ
+++ b/Dockerfile33.templ
@@ -22,6 +22,7 @@ RUN apt-get update && \
         ca-certificates \
         pwgen \
         curl \
+        numactl \
     && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -61,4 +61,20 @@ if [ "$1" == "arangod" ]; then
     set -- arangod --server.disable-authentication="$DISABLE_AUTHENTICATION" "$@"
 fi
 
+if [ ! -z "$ARANGO_USE_NUMA_INTERLEAVE_ALL" ]; then
+    echo "Will try to enable NUMA interleave on all nodes..."
+    set +e
+    # check numactl usability to provide a hint if container is not running in
+    # privileged mode
+    numa='numactl --interleave=all'
+    $numa sleep 0
+    if [ $? -ne 0 ]
+        then
+        echo >&2 "error: cannot use numactl, if you are sure that it is supported by your hardware and system, please check that container is running in privileged mode or use docker --security-opt seccomp=unconfined"
+    else
+        set -- $numa "$@"
+    fi
+    set -e
+fi
+
 exec "$@"

--- a/docker-entrypoint3.sh
+++ b/docker-entrypoint3.sh
@@ -131,4 +131,20 @@ if [ "$1" = 'arangod' ]; then
     set -- arangod --server.authentication="$AUTHENTICATION" "$@"
 fi
 
+if [ ! -z "$ARANGO_USE_NUMA_INTERLEAVE_ALL" ]; then
+    echo "Will try to enable NUMA interleave on all nodes..."
+    set +e
+    # check numactl usability to provide a hint if container is not running in
+    # privileged mode
+    numa='numactl --interleave=all'
+    $numa sleep 0
+    if [ $? -ne 0 ]
+        then
+        echo >&2 "error: cannot use numactl, if you are sure that it is supported by your hardware and system, please check that container is running in privileged mode or use docker --security-opt seccomp=unconfined"
+    else
+        set -- $numa "$@"
+    fi
+    set -e
+fi
+
 exec "$@"

--- a/docker-entrypoint32.sh
+++ b/docker-entrypoint32.sh
@@ -145,4 +145,20 @@ if [ "$1" = 'arangod' ]; then
     set -- arangod "$@" --server.authentication="$AUTHENTICATION" --config /tmp/arangod.conf
 fi
 
+if [ ! -z "$ARANGO_USE_NUMA_INTERLEAVE_ALL" ]; then
+    echo "Will try to enable NUMA interleave on all nodes..."
+    set +e
+    # check numactl usability to provide a hint if container is not running in
+    # privileged mode
+    numa='numactl --interleave=all'
+    $numa sleep 0
+    if [ $? -ne 0 ]
+        then
+        echo >&2 "error: cannot use numactl, if you are sure that it is supported by your hardware and system, please check that container is running in privileged mode or use docker --security-opt seccomp=unconfined"
+    else
+        set -- $numa "$@"
+    fi
+    set -e
+fi
+
 exec "$@"

--- a/docker-entrypoint33.sh
+++ b/docker-entrypoint33.sh
@@ -145,4 +145,20 @@ if [ "$1" = 'arangod' ]; then
     set -- arangod "$@" --server.authentication="$AUTHENTICATION" --config /tmp/arangod.conf
 fi
 
+if [ ! -z "$ARANGO_USE_NUMA_INTERLEAVE_ALL" ]; then
+    echo "Will try to enable NUMA interleave on all nodes..."
+    set +e
+    # check numactl usability to provide a hint if container is not running in
+    # privileged mode
+    numa='numactl --interleave=all'
+    $numa sleep 0
+    if [ $? -ne 0 ]
+        then
+        echo >&2 "error: cannot use numactl, if you are sure that it is supported by your hardware and system, please check that container is running in privileged mode or use docker --security-opt seccomp=unconfined"
+    else
+        set -- $numa "$@"
+    fi
+    set -e
+fi
+
 exec "$@"

--- a/docker-entrypoint34.sh
+++ b/docker-entrypoint34.sh
@@ -145,4 +145,20 @@ if [ "$1" = 'arangod' ]; then
     set -- arangod "$@" --server.authentication="$AUTHENTICATION" --config /tmp/arangod.conf
 fi
 
+if [ ! -z "$ARANGO_USE_NUMA_INTERLEAVE_ALL" ]; then
+    echo "Will try to enable NUMA interleave on all nodes..."
+    set +e
+    # check numactl usability to provide a hint if container is not running in
+    # privileged mode
+    numa='numactl --interleave=all'
+    $numa sleep 0
+    if [ $? -ne 0 ]
+        then
+        echo >&2 "error: cannot use numactl, if you are sure that it is supported by your hardware and system, please check that container is running in privileged mode or use docker --security-opt seccomp=unconfined"
+    else
+        set -- $numa "$@"
+    fi
+    set -e
+fi
+
 exec "$@"


### PR DESCRIPTION
This PR adds an `ARANGO_USE_NUMA_INTERLEAVE_ALL` environment variable that triggers usage of `numactl --interleave all` to prefix the actual command executed by the entrypoint script. 

It will obviously improve performances when running these docker images on NUMA enabled host, but it will also prevent the following message to appear in the logs: 

```
WARNING {memory} It is recommended to set NUMA to interleaved.
WARNING {memory} put 'numactl --interleave=all' in front of your command
```

Sorry if this PR is incomplete, I am not sure I understood all the details of the release flow involved in this repository, also, the link provided in the readme is dead: https://github.com/arangodb/documents/blob/master/Core/arangodb_docker.md